### PR TITLE
fix: ensure toast container reference is updated before rendering

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -16,11 +16,21 @@ btn.addEventListener('click', () => {
 
 // Positions toast example
 const sectionPositions = document.getElementById('section-positions');
-const toasterPositions = document.getElementById('positions');
+
+function createToaster(position) {
+	document.getElementById('positions').remove();
+
+	const toasterElement = document.createElement('wc-beru');
+	toasterElement.setAttribute('id', 'positions');
+	toasterElement.setAttribute('position', position);
+
+	const nodeRef = document.body.firstChild;
+	document.body.insertBefore(toasterElement, nodeRef);
+}
 
 sectionPositions.addEventListener('click', (e) => {
 	if (e.target.id === 'btn-tl') {
-		toasterPositions.setAttribute('position', 'top-left');
+		createToaster('top-left');
 		toast.display('Hello from wc-beru', {
 			description: 'Toast in top left position',
 			beruId: 'positions',
@@ -28,7 +38,7 @@ sectionPositions.addEventListener('click', (e) => {
 	}
 
 	if (e.target.id === 'btn-tc') {
-		toasterPositions.setAttribute('position', 'top-center');
+		createToaster('top-center');
 		toast.display('Hello from wc-beru', {
 			description: 'Toast in top center position',
 			beruId: 'positions',
@@ -36,7 +46,7 @@ sectionPositions.addEventListener('click', (e) => {
 	}
 
 	if (e.target.id === 'btn-tr') {
-		toasterPositions.setAttribute('position', 'top-right');
+		createToaster('top-right');
 		toast.display('Hello from wc-beru', {
 			description: 'Toast in top right position',
 			beruId: 'positions',
@@ -44,7 +54,7 @@ sectionPositions.addEventListener('click', (e) => {
 	}
 
 	if (e.target.id === 'btn-bl') {
-		toasterPositions.setAttribute('position', 'bottom-left');
+		createToaster('bottom-left');
 		toast.display('Hello from wc-beru', {
 			description: 'Toast in bottom left position',
 			beruId: 'positions',
@@ -52,7 +62,7 @@ sectionPositions.addEventListener('click', (e) => {
 	}
 
 	if (e.target.id === 'btn-bc') {
-		toasterPositions.setAttribute('position', 'bottom-center');
+		createToaster('bottom-center');
 		toast.display('Hello from wc-beru', {
 			description: 'Toast in bottom center position',
 			beruId: 'positions',
@@ -60,7 +70,7 @@ sectionPositions.addEventListener('click', (e) => {
 	}
 
 	if (e.target.id === 'btn-br') {
-		toasterPositions.setAttribute('position', 'bottom-right');
+		createToaster('bottom-right');
 		toast.display('Hello from wc-beru', {
 			description: 'Toast in bottom right position',
 			beruId: 'positions',

--- a/lib/scripts/toast.js
+++ b/lib/scripts/toast.js
@@ -37,6 +37,8 @@ export class Toast {
 	 * @description Renders a toast notification with the given data.
 	 */
 	#renderToast(data) {
+		this.setToaster(document.querySelectorAll('wc-beru'));
+
 		let toastIcon = '';
 
 		switch (data.type) {


### PR DESCRIPTION
**Description**

This PR fixes a reference error occurring when a wc-beru instance is destroyed and re-instantiated.

**The Problem:** The node reference for the Toast class was being established only once during the initial call to setToaster. If the instance was recreated, the reference became stale, causing a crash when trying to render a toast because it pointed to a non-existent or detached node.

**The Solution:** Instead of relying on a one-time initialization, the reference to the container node is now updated immediately before each toast is rendered. This ensures that the Toast class always has a valid and current reference to the DOM node, regardless of whether the instance has changed.

**Changes**

Modified the render logic to refresh the container node reference.

Decoupled the node reference from the initial setToaster lifecycle.

**Testing**

1. Instantiate wc-beru.
2. Trigger a Toast (Works).
3. Destroy the instance and create a new one.
4. Trigger a Toast (Previously failed, now works correctly).